### PR TITLE
fix: split usecases in different files

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -39,7 +39,7 @@ SPEC CHECKSUMS:
   connectivity_plus: 07c49e96d7fc92bc9920617b83238c4d178b446a
   Flutter: f04841e97a9d0b0a8025694d0796dd46242b2854
   FMDB: 2ce00b547f966261cd18927a3ddb07cb6f3db82a
-  path_provider_foundation: eaf5b3e458fc0e5fbb9940fb09980e853fe058b8
+  path_provider_foundation: 29f094ae23ebbca9d3d0cec13889cd9060c0e943
   ReachabilitySwift: 985039c6f7b23a1da463388634119492ff86c825
   sqflite: 31f7eba61e3074736dff8807a9b41581e4f7f15a
 

--- a/lib/app/core/utilities/dependency_injector.dart
+++ b/lib/app/core/utilities/dependency_injector.dart
@@ -1,4 +1,6 @@
 import 'package:cloudwalk_assessment/app/data/datasources/local_datasource.dart';
+import 'package:cloudwalk_assessment/app/domain/usecases/get_cached_images_usecase.dart';
+import 'package:cloudwalk_assessment/app/domain/usecases/update_local_db_usecase.dart';
 import 'package:connectivity_plus/connectivity_plus.dart';
 import 'package:get_it/get_it.dart';
 import 'package:hive/hive.dart';
@@ -7,7 +9,7 @@ import 'package:http/http.dart' as http;
 import '../../data/datasources/remote_datasource.dart';
 import '../../data/repositories/repository_impl.dart';
 import '../../domain/repositories/repository.dart';
-import '../../domain/usecases/images_usecase.dart';
+import '../../domain/usecases/get_images_usecase.dart';
 import '../../presentation/cubits/images_cubit.dart';
 
 final sl = GetIt.instance; // the service locator(sl)
@@ -22,10 +24,15 @@ void regSingleton<T extends Object>(T Function() factFunc) {
 
 void init() {
   // can have a separate method as app scales
-  regSingleton(() => ImagesCubit(sl(), sl()));
+  regSingleton(() => ImagesCubit(sl(), sl(), sl(), sl()));
   regSingleton<Connectivity>(() => Connectivity());
-  regSingleton(() => ImagesUsecase(sl()));
+
+  regSingleton(() => GetImagesUsecase(sl()));
+  regSingleton(() => GetCachedImagesUsecase(sl()));
+  regSingleton(() => UpdateLocalDbUsecase(sl()));
+
   regSingleton<Repository>(() => RepositoryImpl(sl(), sl()));
+
   regSingleton<RemoteDataSource>(() => RemoteDataSourceImpl(sl()));
 
   // local data source

--- a/lib/app/domain/usecases/get_cached_images_usecase.dart
+++ b/lib/app/domain/usecases/get_cached_images_usecase.dart
@@ -1,0 +1,11 @@
+import '../entities/image_entity.dart';
+import '../repositories/repository.dart';
+
+class GetCachedImagesUsecase {
+  final Repository repo;
+  GetCachedImagesUsecase(this.repo);
+
+  Future<List<ImageEntity>> execute() async {
+    return await repo.getCachedImages();
+  }
+}

--- a/lib/app/domain/usecases/get_images_usecase.dart
+++ b/lib/app/domain/usecases/get_images_usecase.dart
@@ -4,11 +4,11 @@ import 'package:dartz/dartz.dart';
 import '../../core/utilities/errors/failure.dart';
 import '../entities/image_entity.dart';
 
-class ImagesUsecase {
+class GetImagesUsecase {
   final Repository repo;
-  ImagesUsecase(this.repo);
+  GetImagesUsecase(this.repo);
 
-  Future<Either<Failure, List<ImageEntity>>> getImages() async {
+  Future<Either<Failure, List<ImageEntity>>> execute() async {
     final result = await repo.getImagesRepo();
     return result.fold(
       (failure) => Left(failure),
@@ -16,11 +16,11 @@ class ImagesUsecase {
     );
   }
 
-  Future<void> updateLocalDatabase(List<ImageEntity> images) async {
-    return await repo.updateLocalDatabase(images);
-  }
-
-  Future<List<ImageEntity>> getCachedImages() async {
-    return await repo.getCachedImages();
-  }
+  // Future<void> updateLocalDatabase(List<ImageEntity> images) async {
+  //   return await repo.updateLocalDatabase(images);
+  // }
+  //
+  // Future<List<ImageEntity>> getCachedImages() async {
+  //   return await repo.getCachedImages();
+  // }
 }

--- a/lib/app/domain/usecases/update_local_db_usecase.dart
+++ b/lib/app/domain/usecases/update_local_db_usecase.dart
@@ -1,0 +1,11 @@
+import '../entities/image_entity.dart';
+import '../repositories/repository.dart';
+
+class UpdateLocalDbUsecase {
+  final Repository repo;
+  UpdateLocalDbUsecase(this.repo);
+
+  Future<void> execute(List<ImageEntity> images) async {
+    return await repo.updateLocalDatabase(images);
+  }
+}

--- a/lib/app/presentation/cubits/images_cubit.dart
+++ b/lib/app/presentation/cubits/images_cubit.dart
@@ -1,4 +1,6 @@
-import 'package:cloudwalk_assessment/app/domain/usecases/images_usecase.dart';
+import 'package:cloudwalk_assessment/app/domain/usecases/get_cached_images_usecase.dart';
+import 'package:cloudwalk_assessment/app/domain/usecases/get_images_usecase.dart';
+import 'package:cloudwalk_assessment/app/domain/usecases/update_local_db_usecase.dart';
 import 'package:connectivity_plus/connectivity_plus.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -6,10 +8,17 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'images_states.dart';
 
 class ImagesCubit extends Cubit<ImagesStates> {
-  final ImagesUsecase _usecase;
+  final GetImagesUsecase _getImagesUsecase;
+  final GetCachedImagesUsecase _getCachedImagesUsecase;
+  final UpdateLocalDbUsecase _updateLocalDbUsecase;
   final Connectivity connectivity;
 
-  ImagesCubit(this._usecase, this.connectivity) : super(ImagesInitial());
+  ImagesCubit(
+    this._getImagesUsecase,
+    this._getCachedImagesUsecase,
+    this._updateLocalDbUsecase,
+    this.connectivity,
+  ) : super(ImagesInitial());
 
   Future<void> getImages() async {
     emit(ImagesLoading());
@@ -18,20 +27,20 @@ class ImagesCubit extends Cubit<ImagesStates> {
       final hasInternet = connectivityResult != ConnectivityResult.none;
 
       if (hasInternet) {
-        final result = await _usecase.getImages();
+        final result = await _getImagesUsecase.execute();
         debugPrint("[Internet is Available, Access Remote Datasource]");
         emit(
           result.fold(
             (failure) => ImagesError(failure.message),
             (images) {
-              _usecase.updateLocalDatabase(images);
+              _updateLocalDbUsecase.execute(images);
               return ImagesLoaded(images);
             },
           ),
         );
       } else {
         debugPrint("[Internet is Unavailable, Access Local Datasource]");
-        final cachedImages = await _usecase.getCachedImages();
+        final cachedImages = await _getCachedImagesUsecase.execute();
         emit(ImagesLoaded(cachedImages));
       }
     } catch (error) {

--- a/test/app/core/utilities/di_test.dart
+++ b/test/app/core/utilities/di_test.dart
@@ -3,7 +3,7 @@ import 'package:cloudwalk_assessment/app/core/utilities/dependency_injector.dart
 import 'package:cloudwalk_assessment/app/data/datasources/local_datasource.dart';
 import 'package:cloudwalk_assessment/app/data/datasources/remote_datasource.dart';
 import 'package:cloudwalk_assessment/app/domain/repositories/repository.dart';
-import 'package:cloudwalk_assessment/app/domain/usecases/images_usecase.dart';
+import 'package:cloudwalk_assessment/app/domain/usecases/get_images_usecase.dart';
 import 'package:cloudwalk_assessment/app/presentation/cubits/images_cubit.dart';
 import 'package:connectivity_plus/connectivity_plus.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -26,7 +26,7 @@ void main() {
     // verify that the dependencies are registered correctly
     expect(sl.isRegistered<ImagesCubit>(), isTrue);
     expect(sl.isRegistered<Connectivity>(), isTrue);
-    expect(sl.isRegistered<ImagesUsecase>(), isTrue);
+    expect(sl.isRegistered<GetImagesUsecase>(), isTrue);
     expect(sl.isRegistered<Repository>(), isTrue);
     expect(sl.isRegistered<RemoteDataSource>(), isTrue);
     expect(sl.isRegistered<LocalDataSource>(), isTrue);
@@ -36,7 +36,7 @@ void main() {
     // verify the types of the registered dependencies
     expect(sl<ImagesCubit>(), isA<ImagesCubit>());
     expect(sl<Connectivity>(), isA<Connectivity>());
-    expect(sl<ImagesUsecase>(), isA<ImagesUsecase>());
+    expect(sl<GetImagesUsecase>(), isA<GetImagesUsecase>());
     expect(sl<Repository>(), isA<Repository>());
     expect(sl<RemoteDataSource>(), isA<RemoteDataSource>());
     expect(sl<LocalDataSource>(), isA<LocalDataSource>());

--- a/test/app/core/utilities/test_helper.dart
+++ b/test/app/core/utilities/test_helper.dart
@@ -3,7 +3,7 @@ import 'package:cloudwalk_assessment/app/data/datasources/remote_datasource.dart
 import 'package:cloudwalk_assessment/app/data/repositories/repository_impl.dart';
 import 'package:cloudwalk_assessment/app/domain/entities/image_entity.dart';
 import 'package:cloudwalk_assessment/app/domain/repositories/repository.dart';
-import 'package:cloudwalk_assessment/app/domain/usecases/images_usecase.dart';
+import 'package:cloudwalk_assessment/app/domain/usecases/get_images_usecase.dart';
 import 'package:cloudwalk_assessment/app/presentation/cubits/images_cubit.dart';
 import 'package:connectivity_plus/connectivity_plus.dart';
 import 'package:flutter/services.dart';
@@ -13,7 +13,7 @@ import 'package:mockito/annotations.dart';
 
 @GenerateMocks([
   ImagesCubit,
-  ImagesUsecase,
+  GetImagesUsecase,
   Repository,
   RepositoryImpl,
   RemoteDataSource,

--- a/test/app/core/utilities/test_helper.mocks.dart
+++ b/test/app/core/utilities/test_helper.mocks.dart
@@ -20,7 +20,7 @@ import 'package:cloudwalk_assessment/app/domain/entities/image_entity.dart'
     as _i16;
 import 'package:cloudwalk_assessment/app/domain/repositories/repository.dart'
     as _i4;
-import 'package:cloudwalk_assessment/app/domain/usecases/images_usecase.dart'
+import 'package:cloudwalk_assessment/app/domain/usecases/get_images_usecase.dart'
     as _i14;
 import 'package:cloudwalk_assessment/app/presentation/cubits/images_cubit.dart'
     as _i11;
@@ -354,22 +354,24 @@ class MockRepository extends _i1.Mock implements _i4.Repository {
   }
 
   @override
-  _i12.Future<_i5.Either<_i15.Failure, List<_i16.ImageEntity>>>
-      getImagesRepo() => (super.noSuchMethod(
-            Invocation.method(
-              #getImagesRepo,
-              [],
-            ),
-            returnValue: _i12
-                .Future<_i5.Either<_i15.Failure, List<_i16.ImageEntity>>>.value(
+  _i12.Future<
+      _i5
+          .Either<_i15.Failure, List<_i16.ImageEntity>>> getImagesRepo() =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #getImagesRepo,
+          [],
+        ),
+        returnValue:
+            _i12.Future<_i5.Either<_i15.Failure, List<_i16.ImageEntity>>>.value(
                 _FakeEither_3<_i15.Failure, List<_i16.ImageEntity>>(
-              this,
-              Invocation.method(
-                #getImagesRepo,
-                [],
-              ),
-            )),
-          ) as _i12.Future<_i5.Either<_i15.Failure, List<_i16.ImageEntity>>>);
+          this,
+          Invocation.method(
+            #getImagesRepo,
+            [],
+          ),
+        )),
+      ) as _i12.Future<_i5.Either<_i15.Failure, List<_i16.ImageEntity>>>);
   @override
   _i12.Future<void> updateLocalDatabase(List<_i16.ImageEntity>? images) =>
       (super.noSuchMethod(
@@ -416,22 +418,24 @@ class MockRepositoryImpl extends _i1.Mock implements _i17.RepositoryImpl {
         ),
       ) as _i7.LocalDataSource);
   @override
-  _i12.Future<_i5.Either<_i15.Failure, List<_i16.ImageEntity>>>
-      getImagesRepo() => (super.noSuchMethod(
-            Invocation.method(
-              #getImagesRepo,
-              [],
-            ),
-            returnValue: _i12
-                .Future<_i5.Either<_i15.Failure, List<_i16.ImageEntity>>>.value(
+  _i12.Future<
+      _i5
+          .Either<_i15.Failure, List<_i16.ImageEntity>>> getImagesRepo() =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #getImagesRepo,
+          [],
+        ),
+        returnValue:
+            _i12.Future<_i5.Either<_i15.Failure, List<_i16.ImageEntity>>>.value(
                 _FakeEither_3<_i15.Failure, List<_i16.ImageEntity>>(
-              this,
-              Invocation.method(
-                #getImagesRepo,
-                [],
-              ),
-            )),
-          ) as _i12.Future<_i5.Either<_i15.Failure, List<_i16.ImageEntity>>>);
+          this,
+          Invocation.method(
+            #getImagesRepo,
+            [],
+          ),
+        )),
+      ) as _i12.Future<_i5.Either<_i15.Failure, List<_i16.ImageEntity>>>);
   @override
   _i12.Future<void> updateLocalDatabase(List<_i16.ImageEntity>? images) =>
       (super.noSuchMethod(

--- a/test/app/data/datasources/local_datasource_test.dart
+++ b/test/app/data/datasources/local_datasource_test.dart
@@ -1,6 +1,6 @@
 import 'package:cloudwalk_assessment/app/core/utilities/errors/failure.dart';
 import 'package:cloudwalk_assessment/app/domain/entities/image_entity.dart';
-import 'package:cloudwalk_assessment/app/domain/usecases/images_usecase.dart';
+import 'package:cloudwalk_assessment/app/domain/usecases/get_images_usecase.dart';
 import 'package:dartz/dartz.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
@@ -8,13 +8,13 @@ import 'package:mockito/mockito.dart';
 import '../../core/utilities/test_helper.mocks.dart';
 
 void main() {
-  late ImagesUsecase usecase;
+  late GetImagesUsecase getImagesUsecase;
   late MockRepository mockRepository;
 
   // set up the test environment by creating a mock repository instance
   setUp(() {
     mockRepository = MockRepository();
-    usecase = ImagesUsecase(mockRepository);
+    getImagesUsecase = GetImagesUsecase(mockRepository);
   });
 
   // define a list of mock ImageEntity objects for testing
@@ -41,7 +41,7 @@ void main() {
     );
 
     // call the use case's getImages method and store the result
-    final result = await usecase.getImages();
+    final result = await getImagesUsecase.execute();
 
     // verify that the result is equal to Right(mockImages)
     expect(result, equals(Right(mockImages)));
@@ -64,7 +64,7 @@ void main() {
     );
 
     // call the use case's getImages method and store the result
-    final result = await usecase.getImages();
+    final result = await getImagesUsecase.execute();
 
     // verify that the result is equal to Left(failure)
     expect(result, equals(const Left(failure)));

--- a/test/app/domain/usecases/images_usecase_test.dart
+++ b/test/app/domain/usecases/images_usecase_test.dart
@@ -1,6 +1,6 @@
 import 'package:cloudwalk_assessment/app/core/utilities/errors/failure.dart';
 import 'package:cloudwalk_assessment/app/domain/entities/image_entity.dart';
-import 'package:cloudwalk_assessment/app/domain/usecases/images_usecase.dart';
+import 'package:cloudwalk_assessment/app/domain/usecases/get_images_usecase.dart';
 import 'package:dartz/dartz.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';


### PR DESCRIPTION
In this PR, I fixed the con of usecase having more than one responsibility. I achieved this by splitting the functions within the usecase in their own respective files and class names